### PR TITLE
Unify name of bias parameters with madgwick

### DIFF
--- a/cfg/FdilinkAhrs.cfg
+++ b/cfg/FdilinkAhrs.cfg
@@ -5,9 +5,9 @@ from dynamic_reconfigure.parameter_generator_catkin import *
 
 gen = ParameterGenerator()
 
-gen.add("mag_offset_x", double_t, 0, "Magnetometer offset x (hard iron correction), x component", 0, -500, 500)
-gen.add("mag_offset_y", double_t, 0, "Magnetometer offset y (hard iron correction), y component", 0, -500, 500)
-gen.add("mag_offset_z", double_t, 0, "Magnetometer offset z (hard iron correction), z component", 0, -500, 500)
+gen.add("mag_bias_x", double_t, 0, "Magnetometer offset x (hard iron correction), x component", 0, -500, 500)
+gen.add("mag_bias_y", double_t, 0, "Magnetometer offset y (hard iron correction), y component", 0, -500, 500)
+gen.add("mag_bias_z", double_t, 0, "Magnetometer offset z (hard iron correction), z component", 0, -500, 500)
 gen.add("mag_covariance", double_t, 0, "Magnetic field covariance", 0, -500, 500)
 
 exit(gen.generate(PACKAGE, "dynamic_reconfigure_node", "FdilinkAhrs"))

--- a/cfg/FdilinkAhrs.cfg
+++ b/cfg/FdilinkAhrs.cfg
@@ -5,9 +5,9 @@ from dynamic_reconfigure.parameter_generator_catkin import *
 
 gen = ParameterGenerator()
 
-gen.add("mag_bias_x", double_t, 0, "Magnetometer offset x (hard iron correction), x component", 0, -500, 500)
-gen.add("mag_bias_y", double_t, 0, "Magnetometer offset y (hard iron correction), y component", 0, -500, 500)
-gen.add("mag_bias_z", double_t, 0, "Magnetometer offset z (hard iron correction), z component", 0, -500, 500)
-gen.add("mag_covariance", double_t, 0, "Magnetic field covariance", 0, -500, 500)
+gen.add("mag_bias_x", double_t, 0, "Magnetometer offset x (hard iron correction), x component", 0, -1, 1)
+gen.add("mag_bias_y", double_t, 0, "Magnetometer offset y (hard iron correction), y component", 0, -1, 1)
+gen.add("mag_bias_z", double_t, 0, "Magnetometer offset z (hard iron correction), z component", 0, -1, 1)
+gen.add("mag_covariance", double_t, 0, "Magnetic field covariance", 0, -1, 1)
 
 exit(gen.generate(PACKAGE, "dynamic_reconfigure_node", "FdilinkAhrs"))

--- a/src/ahrs_driver.cpp
+++ b/src/ahrs_driver.cpp
@@ -528,9 +528,9 @@ void ahrsBringup::checkSN(int type)
 
 void ahrsBringup::reconfigCallback(fdilink_ahrs::FdilinkAhrsConfig &config, uint32_t level)
 {
-  mag_offset_x_ = config.mag_offset_x;
-  mag_offset_y_ = config.mag_offset_y;
-  mag_offset_z_ = config.mag_offset_z;
+  mag_offset_x_ = config.mag_bias_x;
+  mag_offset_y_ = config.mag_bias_y;
+  mag_offset_z_ = config.mag_bias_z;
   mag_covariance_ = config.mag_covariance;
   ROS_INFO("Magnetometer offset values: %f %f %f", mag_offset_x_, mag_offset_y_, mag_offset_z_);
   ROS_INFO("Magnetic Field Constant Covariance: %f", mag_covariance_);

--- a/src/ahrs_driver.cpp
+++ b/src/ahrs_driver.cpp
@@ -421,6 +421,10 @@ void ahrsBringup::processLoop()
         pitch = EulerAngle[1];
       }
 
+      // Convert mG to T
+      magx *= 1.0e-7;
+      magy *= 1.0e-7;
+      magz *= 1.0e-7;
       magx -= mag_offset_x_;
       magy -= mag_offset_y_;
       magz -= mag_offset_z_;
@@ -432,9 +436,9 @@ void ahrsBringup::processLoop()
 
       sensor_msgs::MagneticField mag;
       mag.header = imu_data.header;
-      mag.magnetic_field.x = magx * 1.0e-7;
-      mag.magnetic_field.y = magy * 1.0e-7;
-      mag.magnetic_field.z = magz * 1.0e-7;
+      mag.magnetic_field.x = magx;
+      mag.magnetic_field.y = magy;
+      mag.magnetic_field.z = magz;
       std::fill(mag.magnetic_field_covariance.begin(), mag.magnetic_field_covariance.end(), mag_covariance_);
       mag_pub_.publish(mag);
     }


### PR DESCRIPTION
<!-- あくまでテンプレートなので必ずしもすべての項目を埋めなくてよい -->

<!-- 変更の目的 または 概要-->
## Summary

- mag_offset_[x/y/z] -> mag_bias_[x/y/z] にしてmadgwickのパラメータと名前統一
- mag_bias_[x/y/z]の単位をmG -> T

<!-- このPull Requestで解決されるIssue
fix #issue番号 の形式で記述
fix以外のkeywordはこちら。(https://docs.github.com/ja/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) -->
- fix #10 

<!-- 変更の詳細 -->
## Detail

<!-- この関数を変更したのでこの機能にも影響がある、など -->
## Impact

<!-- どのような動作検証を行ったか -->
## Test
<!-- ROS package向け Template -->
  <!-- * [ ] gazebo環境で起動した
    * [ ] cuboid
    * [ ] signage
  * [ ] 実機環境で起動した
    * [ ] cuboid
    * [ ] signage
  * [ ] (アプリ名)で動作検証した -->

## Attention
<!-- 上記項目以外の補足情報など
例
- レビューをする際に見てほしい点
- ローカル環境で試す際の注意点
- このPull Requestよりも先にマージしなければならないPull Request
- 複数レビュワー指定している場合に、レビュー必須の人(いれば)の指定 -->
